### PR TITLE
Fix domain calculation where domain isn't set

### DIFF
--- a/src/plot.typ
+++ b/src/plot.typ
@@ -275,9 +275,9 @@
 
       let axis = axis-dict.at(name)
       let domain = if i == 0 {
-        d.at("x-domain", default: (0, 0))
+        d.at("x-domain", default: (none, none))
       } else {
-        d.at("y-domain", default: (0, 0))
+        d.at("y-domain", default: (none, none))
       }
       if domain != (none, none) {
         axis.min = util.min(axis.min, ..domain)

--- a/tests/plot/annotation/test.typ
+++ b/tests/plot/annotation/test.typ
@@ -44,3 +44,15 @@
     })
   })
 })
+
+#test-case({
+  import draw: *
+  set-style(rect: (stroke: none))
+
+  plot.plot(size: (6, 4), x-tick-step: 1, {
+    plot.add(domain: (100, 101), calc.sin)
+    plot.annotate(padding: .1, {
+      content( (101.5, 0), [A])
+    })
+  })
+})


### PR DESCRIPTION
Fixes #72 

Changes the default domain from `(0, 0)` to `(none, none)`. It appears just to have been a typo that none of the tests picked up because they all included the origin.

Adjusted MRE (adjusted ticks)
```typ
#test-case({
  import draw: *
  set-style(rect: (stroke: none))

  plot.plot(size: (6, 4), x-tick-step: 0.5, {
    plot.add(domain: (100, 101), calc.sin)
    plot.annotate(padding: .1, {
      content( (101.5, 0), [A])
    })
  })
})
```

![image](https://github.com/user-attachments/assets/29b49987-6c85-4c06-9c09-89c26a802e32)
