### PR TITLE
Barchart styling

### DIFF
--- a/gallery/barchart.typ
+++ b/gallery/barchart.typ
@@ -13,12 +13,11 @@
 )
 
 #canvas({
-  draw.set-style(legend: (fill: white))
+  draw.set-style(legend: (fill: white), barchart: (bar-width: .8, cluster-gap: 0))
   chart.barchart(mode: "clustered",
                  size: (9, auto),
                  label-key: 0,
                  value-key: (..range(1, 5)),
-                 bar-width: .8,
                  x-tick-step: 2.5,
                  data2,
                  labels: ([Low], [Medium], [High], [Very high]),

--- a/src/chart/barchart.typ
+++ b/src/chart/barchart.typ
@@ -17,11 +17,15 @@
 /// they represent.
 ///
 /// = Styling
+/// Can be applied with `cetz.draw.set-style(barchart: (bar-width: 1))`.
+///
 /// *Root*: `barchart`.
 /// #show-parameter-block("bar-width", "float", default: .8, [
 ///   Width of a single bar (basic) or a cluster of bars (clustered) in the plot.])
 /// #show-parameter-block("y-inset", "float", default: 1, [
 ///   Distance of the plot data to the plot's edges on the y-axis of the plot.])
+/// #show-parameter-block("cluster-gap", "float", default: 0, [
+///   Spacing between bars insides a cluster.])
 /// You can use any `plot` or `axes` related style keys, too.
 ///
 /// The `barchart` function is a wrapper of the `plot` API. Arguments passed


### PR DESCRIPTION
This PR fixes the styling in the barchart example and the issue #101. The way the example set the `bar-width` did not work. With this PR the `bar-width` styling is correct.

In addition the documentation is updated so that all kind of styling is documented, as well as how you can change the style for less frustrating styling.