### PR TITLE
Improve annotation of some function arguments

### DIFF
--- a/src/chart/boxwhisker.typ
+++ b/src/chart/boxwhisker.typ
@@ -44,7 +44,7 @@
 ///      q2: 35,                //            Median
 ///      q3: 50)                //            Upper
 ///   ```
-/// - size (array) : Size of chart. If the second entry is auto, it automatically scales to accommodate the number of entries plotted
+/// - size (array): Size of chart. If the second entry is auto, it automatically scales to accommodate the number of entries plotted
 /// - label-key (integer, string): Index in the array where labels of each entry is stored
 /// - mark (string): Mark to use for plotting outliers. Set `none` to disable. Defaults to "x"
 /// - ..plot-args (any): Additional arguments are passed to `plot.plot`

--- a/src/plot/bar.typ
+++ b/src/plot/bar.typ
@@ -143,12 +143,12 @@
 /// - data (array): Array of data items. An item is an array containing a x an one or more y values.
 ///                 For example `(0, 1)` or `(0, 10, 5, 30)`. Depending on the `mode`, the data items
 ///                 get drawn as either clustered or stacked rects.
-/// - x-key: (int,string): Key to use for retrieving a bars x-value from a single data entry.
+/// - x-key (int,string): Key to use for retrieving a bars x-value from a single data entry.
 ///   This value gets passed to the `.at(...)` function of a data item.
-/// - y-key: (auto,int,string,array): Key to use for retrieving a bars y-value. For clustered/stacked
+/// - y-key (auto,int,string,array): Key to use for retrieving a bars y-value. For clustered/stacked
 ///   data, this must be set to a list of keys (e.g. `range(1, 4)`). If set to `auto`, att but the first
 ///   array-values of a data item are used as y-values.
-/// - error-key: (none,int,string,array): Key(s) to use for retrieving a bars y-error.
+/// - error-key (none,int,string,array): Key(s) to use for retrieving a bars y-error.
 /// - mode (string): The mode on how to group data items into bars:
 ///   / basic: Add one bar per data value. If the data contains multiple values,
 ///     group those bars next to each other.

--- a/src/plot/errorbar.typ
+++ b/src/plot/errorbar.typ
@@ -59,14 +59,14 @@
 /// Add x- and/or y-error bars
 ///
 /// - pt (tuple): Error-bar center coordinate tuple: `(x, y)`
-/// - x-error: (float,tuple): Single error or tuple of errors along the x-axis
-/// - y-error: (float,tuple): Single error or tuple of errors along the y-axis
-/// - mark: (none,string): Mark symbol to show at the error position (`pt`).
-/// - mark-size: (number): Size of the mark symbol.
-/// - mark-style: (style): Extra style to apply to the mark symbol.
+/// - x-error (float,tuple): Single error or tuple of errors along the x-axis
+/// - y-error (float,tuple): Single error or tuple of errors along the y-axis
+/// - mark (none,string): Mark symbol to show at the error position (`pt`).
+/// - mark-size (number): Size of the mark symbol.
+/// - mark-style (style): Extra style to apply to the mark symbol.
 /// - whisker-size (float): Width of the error bar whiskers in canvas units.
 /// - style (dictionary): Style for the error bars
-/// - label: (none,content): Label to tsh
+/// - label (none,content): Label to tsh
 /// - axes (axes): Plot axes. To draw a horizontal growing bar chart, you can swap the x and y axes.
 #let add-errorbar(pt,
                   x-error: 0,

--- a/src/plot/legend.typ
+++ b/src/plot/legend.typ
@@ -93,9 +93,9 @@
 /// - label (none, auto, content): Legend label or auto to use the enumerated default label
 /// - preview (auto, function): Legend preview icon function of the format `item => elements`.
 ///                             Note that the canvas bounds for drawing the preview are (0,0) to (1,1).
-/// - mark: (none,string): Legend mark symbol
-/// - mark-style: (none,dictionary): Mark style
-/// - mark-size: (number): Mark size
+/// - mark (none,string): Legend mark symbol
+/// - mark-style (none,dictionary): Mark style
+/// - mark-size (number): Mark size
 /// - ..style (styles): Style keys for the single item
 #let item(label, preview, mark: none, mark-style: (:), mark-size: 1, ..style) = {
   assert.eq(style.pos().len(), 0,


### PR DESCRIPTION
Tidy, the documentation generator used by this project, expects arguments to be annotated with the following format: "- argument (types): description". However, some comments were written like "- argument: (types): description" (note the colon after the argument name), which made tidy no longer recognize these types and assume they were part of the previous segment.