### PR TITLE
Compute correct position for manual ticks when using log mode

### DIFF
--- a/src/axes.typ
+++ b/src/axes.typ
@@ -269,8 +269,13 @@
 #let value-on-axis(axis, v) = {
   if v == none { return }
   let (min, max) = (axis.min, axis.max)
-  let dt = max - min; if dt == 0 { dt = 1 }
+  if axis.mode == "log" {
+    min = calc.log(min)
+    max = calc.log(max)
+    v = calc.log(v)
+  }
 
+  let dt = max - min; if dt == 0 { dt = 1 }
   return (v - min) / dt
 }
 


### PR DESCRIPTION
Make the `value-on-axis` function take into account whether the axis is logarithmic or linear. This fixes #94