### PR TITLE
Piechart bugfix: draw inner labelon layer 1 instead of 0

### DIFF
--- a/src/chart/piechart.typ
+++ b/src/chart/piechart.typ
@@ -458,7 +458,7 @@
             angle = vector.add(pt, (dir.at(1), -dir.at(0)))
           }
 
-          content(pt, inner-label, angle: angle, anchor: style.inner-label.anchor)
+          on-layer(1, content(pt, inner-label, angle: angle, anchor: style.inner-label.anchor))
         }
 
         // Place item anchor


### PR DESCRIPTION
- [X] All tests pass locally

I encountered this issue/bug:
```
#import "@preview/cetz:0.3.4"
#import "@preview/cetz-plot:0.1.1": chart

#cetz.canvas({
  chart.piechart(
    (
      ([], 100),
      ([], 1),
    ),
    value-key: 1,
    label-key: 0,
    radius: 4,
    slice-style: (green, red),
    inner-label: (content: (value, label) => "test", radius: 110%),
    outer-label: (content: (value, label) => "test"))
})
```
![Screenshot_20250605_153618](https://github.com/user-attachments/assets/d79294e6-7c12-4b5d-b8c0-ffb5144c4ebd)

As you see, the inner label for the red thing is drawn under the green area. That makes the label unreadable, which is terrible. This especially happens when having plots with very small values.

I assume it is because the green area gets drawn after the text. Changing the entire draw order could be pretty difficult. Hence, this PR changes the layer that the inner label is drawn on to 1 instead of 0, which fixes the problem.

With the fix:
![Screenshot_20250605_154756](https://github.com/user-attachments/assets/86a7468e-b965-4c9f-8f74-c5cd124fe159)